### PR TITLE
fix(oci): clean build-time /var state from OCI layer

### DIFF
--- a/elements/oci/layers/bluefin-stack.bst
+++ b/elements/oci/layers/bluefin-stack.bst
@@ -3,3 +3,18 @@ kind: stack
 depends:
   - bluefin/deps.bst
   - gnome-build-meta.bst:oci/gnomeos/stack.bst
+
+public:
+  bst:
+    integration-commands:
+      # Wipe /var (may contain build-time state) and all FHS dirs that should
+      # be symlinks into /var, then recreate with the correct structure.
+      # Relative symlinks (var/home not /var/home) match zirconium-hawaii and
+      # are safer in chroot/deploy tooling flows.
+      - rm -rfv /home /root /opt /mnt /srv /var
+      - mkdir -p /var/home /var/roothome /var/opt /var/mnt /var/srv /var/tmp
+      - ln -s var/home /home
+      - ln -s var/roothome /root
+      - ln -s var/opt /opt
+      - ln -s var/mnt /mnt
+      - ln -s var/srv /srv


### PR DESCRIPTION
## Problem

`bootc upgrade` fails on the NUC with:
```
error: Upgrading composefs: Performing Upgrade Operation: Writing composefs state:
Failed to create symlink for /var: File exists (os error 17)
```

Build-time `/var` state leaks into the OCI layer. bootc manages `/var` at runtime and expects it clean in the image. When bootc tries to create a symlink for `/var` as a composefs state overlay, it finds `/var` already exists as a real directory.

## Fix

Add `integration-commands` to `elements/oci/layers/bluefin-stack.bst` that run after gnome-build-meta's and normalize the final `/var` state:

- Wipe `/var` (drops all accumulated build-time state)
- Wipe FHS dirs that should be symlinks (`/home`, `/root`, `/opt`, `/mnt`, `/srv`)
- Recreate `/var/{home,roothome,opt,mnt,srv,tmp}` directories
- Create relative symlinks (`var/home`) instead of absolute (`/var/home`) — safer in chroot/deploy tooling flows, matches zirconium-hawaii pattern
- Add `/var/srv` + `/srv` symlink (was missing from gnome-build-meta)
- Add `/var/tmp`

## Verification

After build, confirm:
- `/home` → `var/home` (relative symlink)
- `/root` → `var/roothome` (relative symlink)
- `/opt` → `var/opt` (relative symlink)
- `/mnt` → `var/mnt` (relative symlink)
- `/srv` → `var/srv` (relative symlink)
- `/var/tmp` exists as directory
- `/var` contains only those six subdirs — no leaked build-time state
- `bootc container lint` passes cleanly

## References

- Fixes #115
- Reference implementation: [zirconium-hawaii stack.bst](https://github.com/zirconium-dev/zirconium-hawaii/blob/main/elements/oci/zirconium/stack.bst)
- Fix already present in `projectbluefin/dakota` upstream as of commit `82f7a8f`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>