### PR TITLE
feat(test): add just validate, lint-patches, and CI actionlint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,40 @@ jobs:
         with:
           tool: just
 
+      # ── Static analysis ────────────────────────────────────────────────
+      # Run actionlint + shellcheck on all workflow YAML. This catches
+      # type errors, expression mistakes, and embedded shell bugs before
+      # the full BST graph traversal runs.
+      - name: Install actionlint
+        uses: taiki-e/install-action@f48d2f8ba2b452934c948b7be1a768079c3632ff # v2
+        with:
+          tool: actionlint
+
+      - name: Lint GitHub Actions workflows
+        run: actionlint -config-file .github/actionlint.yaml
+
+      # ── Patch structure check ──────────────────────────────────────────
+      # Warn (non-fatal) when patches are missing an Upstream-Status header.
+      # Prints a summary but does not fail the job — run `just lint-patches`
+      # locally to see the full list and fix before opening a PR.
+      - name: Check patch Upstream-Status headers
+        run: |
+          VALID='Submitted|Accepted|Pending|Not-applicable'
+          MISSING=()
+          while IFS= read -r -d '' patch; do
+            status="$(grep -m1 'Upstream-Status:' "$patch" | sed 's/.*Upstream-Status:[[:space:]]*//' | tr -d '\r\n' || true)"
+            if [[ -z "$status" ]] || ! echo "$status" | grep -qE "^(${VALID})"; then
+              MISSING+=("$patch")
+            fi
+          done < <(find patches/ -name '*.patch' -print0 | sort -z)
+          total=$(find patches/ -name '*.patch' | wc -l)
+          echo "Patch lint: $((total - ${#MISSING[@]}))/${total} patches have a valid Upstream-Status header."
+          if [[ ${#MISSING[@]} -gt 0 ]]; then
+            echo "Missing or invalid Upstream-Status (${#MISSING[@]}):"
+            printf '  %s\n' "${MISSING[@]}"
+            echo "Run: just lint-patches  to see full details"
+          fi
+
       # Cache the BST workspace (junction git sources + bst2 container layers).
       # Key includes junction element refs so junction bumps start fresh.
       # Without this, bst show must clone gnome-build-meta + freedesktop-sdk

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ This is in the pull request template: `[ ] I am using an agent and I take respon
 **The `Justfile` is the single, canonical source of truth for all maintenance tasks.**
 
 * **No "Loose" Commands:** Agents are strictly forbidden from suggesting or using shell commands that are not encapsulated within the `Justfile`.
-* **Current exception:** Until `just validate` is added (tracked in issue #506), element graph validation is run as: `BST_FLAGS="-o x86_64_v3 true --no-interactive" just bst show --deps all oci/bluefin.bst`. This is the only permitted loose command and only until the recipe exists.
+* **Validation:** Use `just validate` to check the full element graph before any PR (closes #506). This mirrors the CI validate job exactly — bst2 pin check + `bst show` for both default and nvidia variants.
 * **Gap Closure:** If an agent identifies a maintenance task, setup step, or deployment requirement not currently covered by a `just` recipe, the agent **MUST** submit a PR to update the `Justfile` before or alongside the feature code.
 * **Determinism:** All recipes added by agents must be idempotent and deterministic.
 

--- a/Justfile
+++ b/Justfile
@@ -45,6 +45,47 @@ bst *ARGS:
         "{{bst2_image}}" \
         bash -c 'bst --colors "$@"' -- ${BST_FLAGS:-} {{ARGS}}
 
+# Validate BST element graph — mirrors the CI validate job exactly.
+# Checks both default and nvidia variants without building anything.
+# Run this before opening any PR to catch element graph errors early.
+#
+# Also verifies the bst2 container image SHA is consistent between
+# the Justfile and .github/workflows/track-bst-sources.yml (same
+# check CI runs on every pull_request).
+#
+# Usage: just validate
+[group('dev')]
+validate:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    echo "==> Checking bst2 image pin consistency..."
+    just_sha="$(grep -oE 'bst2:[a-f0-9]{40}' Justfile | cut -d: -f2)"
+    track_sha="$(grep -oE 'bst2:[a-f0-9]{40}' .github/workflows/track-bst-sources.yml | cut -d: -f2)"
+    if [[ -z "$just_sha" || -z "$track_sha" ]]; then
+        echo "ERROR: could not find bst2 SHA (Justfile: '${just_sha:-missing}', track-bst-sources.yml: '${track_sha:-missing}')"
+        exit 1
+    fi
+    [[ "$just_sha" == "$track_sha" ]] || {
+        echo "ERROR: bst2 pin drift"
+        echo "  Justfile:              $just_sha"
+        echo "  track-bst-sources.yml: $track_sha"
+        echo "  Run: just bst to see the correct SHA, then update both files."
+        exit 1
+    }
+    echo "OK: bst2 pins consistent: $just_sha"
+    echo ""
+
+    echo "==> Validating BST element graph (default)..."
+    BST_FLAGS="-o x86_64_v3 true --no-interactive" just bst show --deps all oci/bluefin.bst
+    echo ""
+
+    echo "==> Validating BST element graph (nvidia)..."
+    BST_FLAGS="-o x86_64_v3 true --no-interactive" just bst show --deps all oci/bluefin-nvidia.bst
+    echo ""
+
+    echo "==> Validation passed."
+
 # ── Build ─────────────────────────────────────────────────────────────
 # Build the OCI image and load it into podman.
 #
@@ -808,3 +849,60 @@ lint:
     $SUDO_CMD podman run --rm --privileged --pull=never \
         "{{image_name}}:{{image_tag}}" \
         bootc container lint
+
+# ── Lint patches ────────────────────────────────────────────────────
+# Check all patch files in patches/ for required Upstream-Status header.
+# Valid values: Submitted | Accepted | Pending | Not-applicable
+#
+# Run this before committing new patches. It is informational and does
+# not block the build — the goal is to keep patch debt visible.
+#
+# Usage: just lint-patches
+[group('test')]
+lint-patches:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    VALID_STATUSES='Submitted|Accepted|Pending|Not-applicable'
+    FAIL=0
+    TOTAL=0
+    MISSING=()
+    INVALID=()
+
+    while IFS= read -r -d '' patch; do
+        TOTAL=$((TOTAL + 1))
+        # Extract the Upstream-Status value (first occurrence)
+        status="$(grep -m1 'Upstream-Status:' "$patch" | sed 's/.*Upstream-Status:[[:space:]]*//' | tr -d '\r\n' || true)"
+        if [[ -z "$status" ]]; then
+            MISSING+=("$patch")
+            FAIL=1
+        elif ! echo "$status" | grep -qE "^(${VALID_STATUSES})"; then
+            INVALID+=("$patch: '$status'")
+            FAIL=1
+        fi
+    done < <(find patches/ -name '*.patch' -print0 | sort -z)
+
+    echo "==> Patch lint results ($TOTAL patches checked)"
+    echo ""
+
+    if [[ ${#MISSING[@]} -gt 0 ]]; then
+        echo "MISSING Upstream-Status (${#MISSING[@]}):";
+        printf '  %s\n' "${MISSING[@]}"
+        echo ""
+    fi
+
+    if [[ ${#INVALID[@]} -gt 0 ]]; then
+        echo "INVALID Upstream-Status (${#INVALID[@]}):";
+        printf '  %s\n' "${INVALID[@]}"
+        echo "  Valid values: Submitted | Accepted | Pending | Not-applicable"
+        echo ""
+    fi
+
+    if [[ $FAIL -eq 0 ]]; then
+        echo "PASS: all patches have a valid Upstream-Status header."
+    else
+        echo "ACTION: Add an Upstream-Status header to each patch listed above."
+        echo "  See: AGENTS.md \"Patch additions or removals\" checklist."
+    fi
+    # Exit 0 always — informational, not a gate.
+    exit 0


### PR DESCRIPTION
## Summary

Extends the testing suite with three new checks: a local validate recipe, a patch lint recipe, and actionlint in CI.

### Changes

**`just validate`** — closes #506

Mirrors the CI `validate` job exactly so developers can run the same checks locally before opening a PR:
- bst2 pin consistency check (Justfile vs `track-bst-sources.yml`)
- `bst show --deps all oci/bluefin.bst` (default variant)
- `bst show --deps all oci/bluefin-nvidia.bst` (nvidia variant)

Replaces the "loose command" exception in `AGENTS.md` now that the recipe exists.

**`just lint-patches`** — new test recipe

Checks all patches in `patches/` for a valid `Upstream-Status:` header (`Submitted` | `Accepted` | `Pending` | `Not-applicable`). Non-gating: exits 0 and prints a summary so patch debt stays visible without blocking builds.

**CI validate job — two new steps**

1. **actionlint** (via existing `taiki-e/install-action`): lints all `.github/workflows/` YAML files using the existing `.github/actionlint.yaml` config. Catches expression errors, type mistakes, and embedded shell bugs before the BST graph traversal runs.

2. **Check patch Upstream-Status headers**: non-fatal summary step — prints how many patches are missing the header and tells reviewers to run `just lint-patches` locally. Does not fail the job.

### Verification

```
just --list   # validate and lint-patches appear under [dev] and [test]
just lint-patches  # runs cleanly, shows current 12/12 patches missing Upstream-Status
```

CI validate: actionlint step runs on every PR, zero false positives expected (existing `.github/actionlint.yaml` suppresses the known `if: false` constant expression warning).

Closes #506

- [x] I am using an agent and I take responsibility for this PR