### PR TITLE
feat(thumbnailer): add codec shim for H.264/H.265 video thumbnails

### DIFF
--- a/elements/bluefin/deps.bst
+++ b/elements/bluefin/deps.bst
@@ -26,6 +26,7 @@ depends:
   - bluefin/composefs-loop-udisks-ignore.bst
   - bluefin/gnome-epub-thumbnailer.bst
   - bluefin/papers-thumbnailer.bst
+  - bluefin/gst-thumbnailer-codec-shim.bst
   - bluefin/wallpapers.bst
 
   - bluefin/jetbrains-mono.bst

--- a/elements/bluefin/gst-thumbnailer-codec-shim.bst
+++ b/elements/bluefin/gst-thumbnailer-codec-shim.bst
@@ -1,0 +1,23 @@
+kind: manual
+
+sources:
+  - kind: local
+    path: files/gst-thumbnailer-codec-shim
+
+build-depends:
+  - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+depends:
+  - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+    - |
+      install -Dm755 gst-thumbnailer-codec-shim \
+        "%{install-root}/usr/lib/bluefin/gst-thumbnailer-codec-shim"
+    - |
+      install -Dm644 z-gst-video-thumbnailer-bluefin.thumbnailer \
+        "%{install-root}/usr/share/thumbnailers/z-gst-video-thumbnailer-bluefin.thumbnailer"

--- a/files/gst-thumbnailer-codec-shim/gst-thumbnailer-codec-shim
+++ b/files/gst-thumbnailer-codec-shim/gst-thumbnailer-codec-shim
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Shim that injects Flatpak ffmpeg-full codecs into the host GStreamer thumbnailer.
+# Finds the active ffmpeg-full extension directory at runtime (path includes a commit hash).
+# Falls back gracefully to the stock thumbnailer if ffmpeg-full is not installed.
+
+FFMPEG_FULL_BASE="/var/lib/flatpak/runtime/org.freedesktop.Platform.ffmpeg-full"
+
+# Find most recent active installation (any arch, any branch)
+FFMPEG_FULL_DIR=$(find "$FFMPEG_FULL_BASE" -maxdepth 4 -name "lib" -type d 2>/dev/null | head -1)
+
+if [ -n "$FFMPEG_FULL_DIR" ]; then
+  export LD_LIBRARY_PATH="$FFMPEG_FULL_DIR:${LD_LIBRARY_PATH:-}"
+  # Force GStreamer to rescan plugins so it discovers the full-codec libavcodec
+  export GST_REGISTRY=/tmp/gst-thumbnailer-codec-shim-registry-$(id -u).bin
+fi
+
+exec /usr/bin/gst-video-thumbnailer "$@"

--- a/files/gst-thumbnailer-codec-shim/z-gst-video-thumbnailer-bluefin.thumbnailer
+++ b/files/gst-thumbnailer-codec-shim/z-gst-video-thumbnailer-bluefin.thumbnailer
@@ -1,0 +1,4 @@
+[Thumbnailer Entry]
+TryExec=/usr/lib/bluefin/gst-thumbnailer-codec-shim
+Exec=/usr/lib/bluefin/gst-thumbnailer-codec-shim --input-uri %u --output %o --size %s
+MimeType=video/3gp;video/3gpp;video/3gpp2;video/mp4;video/mp4v-es;video/mpeg;video/quicktime;video/x-m4v;video/x-matroska;video/x-msvideo;video/webm;video/x-ms-wmv;video/x-flv;video/ogg;video/dv;


### PR DESCRIPTION
## Summary

Adds a lightweight shim that injects Flatpak `org.freedesktop.Platform.ffmpeg-full` codecs into the host `gst-video-thumbnailer`, enabling video thumbnails in Nautilus for H.264/H.265 files.

## Why

freedesktop-sdk explicitly disables H.264/H.265 decoders in FFmpeg for patent reasons:
```
--disable-decoder="h264,hevc,vc1,vvc"
```
This means `gst-video-thumbnailer` cannot decode modern MP4 files and silently fails. Users see generic icons instead of video thumbnails.

## Approach

Rather than building patent-encumbered decoders into the image (which would create licensing liability), this uses the same strategy as Fedora/Ubuntu: the user installs `org.freedesktop.Platform.ffmpeg-full` via Flatpak (it comes automatically with most media apps), and we inject those libs at runtime.

**Files added:**
- `files/gst-thumbnailer-codec-shim/gst-thumbnailer-codec-shim` — shell script that sets `LD_LIBRARY_PATH` to the ffmpeg-full extension, then exec's the real thumbnailer
- `files/gst-thumbnailer-codec-shim/z-gst-video-thumbnailer-bluefin.thumbnailer` — override entry (z- prefix = alphabetically last = wins)
- `elements/bluefin/gst-thumbnailer-codec-shim.bst` — BST import element
- Wired into `elements/bluefin/deps.bst`

## Behavior

| State | Result |
|-------|--------|
| ffmpeg-full installed | ✅ Video thumbnails work |
| ffmpeg-full NOT installed | Graceful fallback — stock thumbnailer runs (no regression) |

## Patent/license safety

No patent-encumbered code is built or distributed in the image. The ffmpeg-full extension is installed by the user via Flatpak, shifting liability the same way every major distro handles this.

## Notes

- Uses per-user `GST_REGISTRY` path to force GStreamer to discover the full-codec libavcodec without corrupting the system plugin cache
- The `z-` prefix ensures our `.thumbnailer` file sorts after the stock one (gnome-desktop uses last-wins for duplicate MIME types)

Closes #196