### PR TITLE
docs(bst): document builders × max-jobs scheduler tuning rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,28 @@ Thanks for helping out!
 Check the [Contributing Guide](https://docs.projectbluefin.io/contributing) for contribution information.
 
 This repository is for building the images, you are probably looking for [@projectbluefin/common](https://github.com/projectbluefin/common) to change something in Bluefin. Make sure you check [the architecture diagram](https://docs.projectbluefin.io/contributing#understanding-bluefins-architecture). 
+
+## Local BuildStream Configuration
+
+### Scheduler Tuning: builders × max-jobs ≈ nproc
+
+BuildStream has two independent parallelism knobs that compound:
+
+| Setting | What it controls | Default |
+|---|---|---|
+| `scheduler.builders` | simultaneous element build sandboxes | 4 |
+| `build.max-jobs` | parallel compile jobs *within* each sandbox | 0 (= nproc) |
+
+**The trap:** `builders: 32` with `max-jobs: 0` (auto) on a 32-core machine → **32 × 32 = 1,024 competing processes**. This causes severe CPU thrashing on source builds (WebKitGTK, gstreamer-plugins-rs, LLVM).
+
+**The rule:** `builders × max-jobs ≈ nproc`
+
+| Machine | builders | max-jobs | result |
+|---|---|---|---|
+| 32-core (ghost) | 16 | 2 | 32 concurrent jobs |
+| 16-core | 8 | 2 | 16 concurrent jobs |
+| 8-core laptop | 4 | 2 | 8 concurrent jobs |
+
+Note: `fetchers` is independent (I/O-bound, not CPU-bound) — keep it high (16–32) to saturate the two remote CAS endpoints (`gbm.gnome.org`, `cache.projectbluefin.io`).
+
+Most builds pull nearly everything from the remote CAS and never hit these limits. This tuning only matters when building elements from source (e.g., after a junction update causes widespread cache misses).


### PR DESCRIPTION
Fixes #222

Documents the builders × max-jobs interaction that causes CPU thrashing when both are set high. Provides a reference table for common machine sizes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>