### PR TITLE
feat: add production environment gate to promotion workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @castrojo @p5 @m2Giles @tulilirockz

--- a/.github/ISSUE_TEMPLATE/pin.yml
+++ b/.github/ISSUE_TEMPLATE/pin.yml
@@ -1,0 +1,25 @@
+name: Pin Request
+description: Ask to pin a package to a specific version in order to avoid regressions
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this bug report! (She bites sometimes). We can pin packages to older, known working versions if there's an issue with an update in Fedora.
+  - type: textarea
+    id: package
+    attributes:
+      label: Describe the Package
+      description: Describe the package you want pinned and why
+      placeholder: Pin foobar to version 1.2
+      value: "Package foobar version 1.2 blew up, we need to revert to 1.1"
+    validations:
+      required: true
+  - type: textarea
+    id: bodhi
+    attributes:
+      label: Bodhi Link (Optional)
+      description: Add the bodhi link to the working version, this is very useful in order to pin a package quickly
+      placeholder: Bodhi link
+      value: "Pin to this version please: https://bodhi.fedoraproject.org/updates/FEDORA-2024-45d587348e"
+    validations:
+      required: false

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,7 +74,7 @@ https://github.com/bootc-dev/bootc/issues/7
 - **Schedule:** nightly at 13:00 UTC (after gnome-build-meta nightly ~08:00 UTC finish)
 - **Publish triggers:** `merge_group`, `schedule`, `workflow_dispatch` (not `pull_request`)
 - **Remote cache:** `cache.projectbluefin.io:11002` (mTLS — `CASD_CLIENT_CERT` + `CASD_CLIENT_KEY`)
-- **Image:** `ghcr.io/projectbluefin/dakota:latest` and `:<sha>`
+- **Image:** `ghcr.io/projectbluefin/dakota:{testing,latest,stable}` and `:<sha>`
 
 ## Key architecture
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,9 +21,9 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: "OCI image to test (default: dakota:latest)"
+        description: "OCI image to test (default: dakota:testing)"
         required: false
-        default: "ghcr.io/projectbluefin/dakota:latest"
+        default: "ghcr.io/projectbluefin/dakota:testing"
       suites:
         description: "Comma-separated GUI suites: smoke,developer,dx,software,vanilla-gnome"
         required: false
@@ -41,5 +41,5 @@ jobs:
   e2e:
     uses: projectbluefin/testsuite/.github/workflows/e2e.yml@main
     with:
-      image: ${{ github.event.inputs.image || 'ghcr.io/projectbluefin/dakota:latest' }}
+      image: ${{ github.event.inputs.image || 'ghcr.io/projectbluefin/dakota:testing' }}
       suites: ${{ github.event.inputs.suites || 'smoke' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,9 @@ on:
         required: false
         default: "smoke"
 
-permissions: read-all
+permissions:
+  contents: read
+  packages: write  # testsuite pushes desktop screenshot to GHCR
 
 concurrency:
   group: e2e-${{ github.ref }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -272,9 +272,9 @@ jobs:
           push-to-registry: true
 
   # ── E2E gate ─────────────────────────────────────────────────────────────
-  # Smoke-tests the freshly pushed :$sha before promoting to :latest.
+  # Smoke-tests the freshly pushed :$sha before promoting to :testing.
   # Only runs on schedule and workflow_dispatch — merge_group does not
-  # produce :latest so there is nothing to gate.
+  # produce :testing so there is nothing to gate.
   e2e-gate:
     needs: [setup, publish]
     if: >-
@@ -287,10 +287,12 @@ jobs:
       suites: smoke
     secrets: inherit
 
-  # ── Promote :latest ───────────────────────────────────────────────────────
-  # Re-tags :$sha as :latest once e2e passes.
+  # ── Promote :testing ──────────────────────────────────────────────────────
+  # Re-tags :$sha as :testing once e2e passes.
+  # Weekly promotion (weekly-testing-promotion.yml) later promotes :testing
+  # to :latest and :stable via digest-pinned re-tagging.
   # NVIDIA is continue-on-error so a failing NVIDIA promote does not
-  # prevent the default :latest from landing.
+  # prevent the default :testing from landing.
   promote:
     needs: [setup, publish, e2e-gate]
     if: needs.e2e-gate.result == 'success'
@@ -305,6 +307,7 @@ jobs:
             continue: true
     continue-on-error: ${{ matrix.continue }}
     permissions:
+      contents: write
       packages: write
     steps:
       - name: Login to GHCR
@@ -314,17 +317,34 @@ jobs:
         run: |
           echo "$GH_TOKEN" | sudo podman login ghcr.io --username "$GH_ACTOR" --password-stdin
 
-      - name: Promote :${{ needs.setup.outputs.sha }} to :latest
+      - name: Promote :${{ needs.setup.outputs.sha }} to :testing
         env:
           BUILD_SHA: ${{ needs.setup.outputs.sha }}
         run: |
           IMAGE="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}${{ matrix.image_suffix }}"
           sudo podman pull "${IMAGE}:${BUILD_SHA}"
-          sudo podman tag "${IMAGE}:${BUILD_SHA}" "${IMAGE}:latest"
+          sudo podman tag "${IMAGE}:${BUILD_SHA}" "${IMAGE}:testing"
           PUSH_OK=false
           for attempt in 1 2 3; do
-            sudo podman push --compression-format=zstd "${IMAGE}:latest" && { PUSH_OK=true; break; }
-            echo "Push attempt ${attempt} failed for :latest, retrying in 5s..."
+            sudo podman push --compression-format=zstd "${IMAGE}:testing" && { PUSH_OK=true; break; }
+            echo "Push attempt ${attempt} failed for :testing, retrying in 5s..."
             [ "$attempt" -lt 3 ] && sleep 5
           done
-          $PUSH_OK || { echo "ERROR: all push attempts failed for :latest"; exit 1; }
+          $PUSH_OK || { echo "ERROR: all push attempts failed for :testing"; exit 1; }
+
+      - name: Fast-forward testing branch
+        if: matrix.image_suffix == ''
+        env:
+          BUILD_SHA: ${{ needs.setup.outputs.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Fast-forward the testing branch to the promoted SHA.
+          # Creates the branch if it doesn't exist yet (first run after setup).
+          gh api repos/${{ github.repository }}/git/refs/heads/testing \
+            --method PATCH \
+            --field sha="$BUILD_SHA" \
+            --field force=false 2>/dev/null || \
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            --field ref="refs/heads/testing" \
+            --field sha="$BUILD_SHA"

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -1,0 +1,214 @@
+name: Weekly Testing Promotion
+
+on:
+  schedule:
+    - cron: '0 6 * * 2' # Tuesday 06:00 UTC (same as bluefin)
+  workflow_dispatch:
+
+concurrency:
+  group: weekly-testing-promotion
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  # ── Resolve current :testing digests ─────────────────────────────────────
+  # Pins the exact digests and verifies both variants share the same source SHA.
+  resolve:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    outputs:
+      source_sha: ${{ steps.verify.outputs.source_sha }}
+      default_digest: ${{ steps.resolve-default.outputs.digest }}
+      nvidia_digest: ${{ steps.resolve-nvidia.outputs.digest }}
+      has_nvidia: ${{ steps.resolve-nvidia.outputs.found }}
+    steps:
+      - name: Login to GHCR (read-only)
+        env:
+          GH_ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "$GH_TOKEN" | sudo podman login ghcr.io --username "$GH_ACTOR" --password-stdin
+
+      - name: Resolve default :testing digest
+        id: resolve-default
+        run: |
+          set -euo pipefail
+          IMAGE="ghcr.io/${{ github.repository_owner }}/dakota:testing"
+          sudo podman pull "$IMAGE"
+          DIGEST=$(sudo podman inspect "$IMAGE" --format '{{.Digest}}')
+          SHA=$(sudo podman inspect "$IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Default :testing → digest=$DIGEST, source_sha=$SHA"
+
+      - name: Resolve NVIDIA :testing digest
+        id: resolve-nvidia
+        run: |
+          set -euo pipefail
+          IMAGE="ghcr.io/${{ github.repository_owner }}/dakota-nvidia:testing"
+          if sudo podman pull "$IMAGE" 2>/dev/null; then
+            DIGEST=$(sudo podman inspect "$IMAGE" --format '{{.Digest}}')
+            SHA=$(sudo podman inspect "$IMAGE" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')
+            echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+            echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "NVIDIA :testing → digest=$DIGEST, source_sha=$SHA"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "NVIDIA :testing not found — skipping NVIDIA promotion"
+          fi
+
+      - name: Verify variants share same source SHA
+        id: verify
+        env:
+          DEFAULT_SHA: ${{ steps.resolve-default.outputs.sha }}
+          NVIDIA_SHA: ${{ steps.resolve-nvidia.outputs.sha }}
+          HAS_NVIDIA: ${{ steps.resolve-nvidia.outputs.found }}
+        run: |
+          set -euo pipefail
+          if [ -z "$DEFAULT_SHA" ]; then
+            echo "ERROR: default :testing has no org.opencontainers.image.revision label"
+            exit 1
+          fi
+
+          if [ "$HAS_NVIDIA" = "true" ] && [ "$NVIDIA_SHA" != "$DEFAULT_SHA" ]; then
+            echo "ERROR: NVIDIA source SHA ($NVIDIA_SHA) != default source SHA ($DEFAULT_SHA)"
+            echo "Variants are out of sync — skipping promotion."
+            echo "Default was built from $DEFAULT_SHA, NVIDIA from $NVIDIA_SHA."
+            exit 1
+          fi
+
+          echo "source_sha=$DEFAULT_SHA" >> "$GITHUB_OUTPUT"
+          echo "Source SHA: $DEFAULT_SHA (both variants match)"
+
+  # ── Check diff — skip if already promoted ────────────────────────────────
+  check-diff:
+    needs: [resolve]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      has_diff: ${{ steps.compare.outputs.has_diff }}
+    steps:
+      - name: Login to GHCR
+        env:
+          GH_ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "$GH_TOKEN" | sudo podman login ghcr.io --username "$GH_ACTOR" --password-stdin
+
+      - name: Compare :testing vs :latest digests
+        id: compare
+        env:
+          TESTING_DIGEST: ${{ needs.resolve.outputs.default_digest }}
+        run: |
+          set -euo pipefail
+          IMAGE="ghcr.io/${{ github.repository_owner }}/dakota:latest"
+          if sudo podman pull "$IMAGE" 2>/dev/null; then
+            LATEST_DIGEST=$(sudo podman inspect "$IMAGE" --format '{{.Digest}}')
+            if [ "$LATEST_DIGEST" = "$TESTING_DIGEST" ]; then
+              echo "No diff between :testing and :latest — nothing to promote"
+              echo "has_diff=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          echo "has_diff=true" >> "$GITHUB_OUTPUT"
+          echo "Promotion needed: :testing differs from :latest"
+
+  # ── Promote :testing → :latest + :stable ────────────────────────────────
+  promote:
+    needs: [resolve, check-diff]
+    if: needs.check-diff.outputs.has_diff == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: default
+            image_suffix: ''
+            digest_key: default_digest
+            continue: false
+          - variant: nvidia
+            image_suffix: '-nvidia'
+            digest_key: nvidia_digest
+            continue: true
+    continue-on-error: ${{ matrix.continue }}
+    steps:
+      - name: Skip if variant unavailable
+        if: matrix.variant == 'nvidia' && needs.resolve.outputs.has_nvidia != 'true'
+        run: |
+          echo "NVIDIA variant not available — skipping"
+          exit 0
+
+      - name: Login to GHCR
+        env:
+          GH_ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "$GH_TOKEN" | sudo podman login ghcr.io --username "$GH_ACTOR" --password-stdin
+
+      - name: Promote to :latest and :stable
+        env:
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          IMAGE="ghcr.io/${{ github.repository_owner }}/dakota${{ matrix.image_suffix }}"
+
+          # Pull the :testing image (already digest-verified in resolve job)
+          sudo podman pull "${IMAGE}:testing"
+
+          # Tag and push as :latest
+          sudo podman tag "${IMAGE}:testing" "${IMAGE}:latest"
+          PUSH_OK=false
+          for attempt in 1 2 3; do
+            sudo podman push --compression-format=zstd "${IMAGE}:latest" && { PUSH_OK=true; break; }
+            echo "Push attempt ${attempt} failed for :latest, retrying in 5s..."
+            [ "$attempt" -lt 3 ] && sleep 5
+          done
+          $PUSH_OK || { echo "ERROR: all push attempts failed for :latest"; exit 1; }
+
+          # Tag and push as :stable
+          sudo podman tag "${IMAGE}:testing" "${IMAGE}:stable"
+          PUSH_OK=false
+          for attempt in 1 2 3; do
+            sudo podman push --compression-format=zstd "${IMAGE}:stable" && { PUSH_OK=true; break; }
+            echo "Push attempt ${attempt} failed for :stable, retrying in 5s..."
+            [ "$attempt" -lt 3 ] && sleep 5
+          done
+          $PUSH_OK || { echo "ERROR: all push attempts failed for :stable"; exit 1; }
+
+          echo "Promoted ${IMAGE}:testing → :latest + :stable (source SHA: $SOURCE_SHA)"
+
+  # ── Fast-forward branches ────────────────────────────────────────────────
+  update-branches:
+    needs: [resolve, promote]
+    if: needs.promote.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Fast-forward latest and stable branches
+        env:
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          REPO="${{ github.repository }}"
+
+          for BRANCH in latest stable; do
+            # Try fast-forward first; create if branch doesn't exist yet.
+            if ! gh api "repos/${REPO}/git/refs/heads/${BRANCH}" \
+                --method PATCH \
+                --field sha="$SOURCE_SHA" \
+                --field force=false 2>/dev/null; then
+              gh api "repos/${REPO}/git/refs" \
+                --method POST \
+                --field ref="refs/heads/${BRANCH}" \
+                --field sha="$SOURCE_SHA"
+              echo "Created ${BRANCH} branch at ${SOURCE_SHA}"
+            else
+              echo "Fast-forwarded ${BRANCH} to ${SOURCE_SHA}"
+            fi
+          done

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -119,6 +119,7 @@ jobs:
 
   # ── Promote :testing → :latest + :stable ────────────────────────────────
   promote:
+    environment: production
     needs: [resolve, check-diff]
     if: needs.check-diff.outputs.has_diff == 'true'
     runs-on: ubuntu-24.04

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,3 +60,20 @@ Non-compliance = automatic rejection.
 **@ mentions in context only.** Only ping someone if asking them to do something specific. Always inside the combined comment — never as a standalone comment.
 
 **When in doubt, don't post.** If the only thing to report is "tests pass", post nothing.
+
+## PR Review
+
+When asked to review a pull request, load the branch workflow before giving feedback:
+
+1. Read [`docs/workflow.md`](docs/workflow.md) — issue lifecycle, labels, and branch flow
+2. Read [`docs/pr-checklist.md`](docs/pr-checklist.md) — per-category checklist (all PRs, junction bumps, patches, OCI, elements)
+
+**Review priorities (in order):**
+
+1. **Branch hygiene** — PR must branch from `upstream/main`, not a fork's local `main`. Check `git diff upstream/main...HEAD --stat` is minimal.
+2. **Checklist compliance** — verify the relevant checklist items from `pr-checklist.md` for the type of change.
+3. **CI gate status** — `validate` and `e2e` are required status checks. If CI hasn't run, note it.
+4. **Scope discipline** — one logical change per PR. Junction bumps must not include patch modifications in the same commit.
+5. **Correctness** — element syntax, layer kind (`compose` not `stack`), cargo sources generated not hand-written, etc.
+
+**Recommend the workflow.** If a contributor's PR doesn't follow the branch flow (e.g., branched from fork `main`, missing `Closes #NNN`, no checklist in PR body), guide them toward the correct pattern documented in `docs/workflow.md` rather than just rejecting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,27 @@ Dakota is a [BuildStream 2](https://buildstream.build/) project producing **Blue
 
 Load **[docs/SKILL.md](docs/SKILL.md)** for the full reference skill tree. Only load docs relevant to your task.
 
+## Org pipeline — projectbluefin
+
+### Repo map
+
+```
+common ──────────────────────────┐
+(shared OCI layer)               │
+                                 ▼
+bluefin  (main→stable)       ←── images ──→ testsuite (e2e gate)
+bluefin-lts (main→lts)       ←── images ──→ testsuite (e2e gate)
+dakota  (main→:latest)       ←── images ──→ testsuite (e2e gate)
+                                 │
+                                 ▼
+                                iso (installation media)
+```
+
+Each image repo pulls `ghcr.io/projectbluefin/common:latest` as a base layer.
+testsuite gates `:latest` promotion in all three image repos.
+
+---
+
 ## Find something to work on
 
 | Time available | Link |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,42 +23,7 @@ dakota  (main→:latest)       ←── images ──→ testsuite (e2e gate)
 Each image repo pulls `ghcr.io/projectbluefin/common:latest` as a base layer.
 testsuite gates `:latest` promotion in all three image repos.
 
----
-
-
-## Org pipeline — projectbluefin
-
-### Repo map
-
-```
-common ──────────────────────────┐
-(shared OCI layer)               │
-                                 ▼
-bluefin  (main→stable)       ←── images ──→ testsuite (e2e gate)
-bluefin-lts (main→lts)       ←── images ──→ testsuite (e2e gate)
-dakota  (main→:latest)       ←── images ──→ testsuite (e2e gate)
-                                 │
-                                 ▼
-                                iso (installation media)
-```
-
-**Dakota's role:** builds Bluefin entirely from source using BuildStream 2 (freedesktop-sdk + gnome-build-meta). No RPMs. The full pipeline: PR → validate + e2e → merge queue → `:sha` → e2e gate → `:latest`.
-testsuite gates `:latest` promotion — `:latest` is never published without a passing e2e smoke test.
-
-## Find something to work on
-
-| Time available | Link |
-|---|---|
-| 30 min | [XS issues](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Aqueue%2Fagent-ready+label%3Asize%2Fxs+no%3Aassignee) |
-| Half day | [S issues](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Aqueue%2Fagent-ready+label%3Asize%2Fs+no%3Aassignee) |
-| Full day | [M issues](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Aqueue%2Fagent-ready+label%3Asize%2Fm+no%3Aassignee) |
-| All | [Everything ready](https://github.com/projectbluefin/dakota/issues?q=is%3Aopen+label%3Aqueue%2Fagent-ready+no%3Aassignee+sort%3Acreated-asc) |
-
-Comment `/claim` on an issue to take it. Actionadon assigns it and removes it from the pool. No PR activity in 7 days returns it automatically.
-
----
-
-## Data donation
+---## Data donation
 
 Dakota bugs are data donations. `ujust report` captures full system state to a user-owned gist before the issue opens. That report is the ground truth.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,26 @@ testsuite gates `:latest` promotion in all three image repos.
 
 ---
 
+
+## Org pipeline — projectbluefin
+
+### Repo map
+
+```
+common ──────────────────────────┐
+(shared OCI layer)               │
+                                 ▼
+bluefin  (main→stable)       ←── images ──→ testsuite (e2e gate)
+bluefin-lts (main→lts)       ←── images ──→ testsuite (e2e gate)
+dakota  (main→:latest)       ←── images ──→ testsuite (e2e gate)
+                                 │
+                                 ▼
+                                iso (installation media)
+```
+
+**Dakota's role:** builds Bluefin entirely from source using BuildStream 2 (freedesktop-sdk + gnome-build-meta). No RPMs. The full pipeline: PR → validate + e2e → merge queue → `:sha` → e2e gate → `:latest`.
+testsuite gates `:latest` promotion — `:latest` is never published without a passing e2e smoke test.
+
 ## Find something to work on
 
 | Time available | Link |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,14 +14,14 @@ common ────────────────────────�
                                  ▼
 bluefin  (main→stable)       ←── images ──→ testsuite (e2e gate)
 bluefin-lts (main→lts)       ←── images ──→ testsuite (e2e gate)
-dakota  (main→:latest)       ←── images ──→ testsuite (e2e gate)
+dakota  (main→testing→latest/stable) ←── images ──→ testsuite (e2e gate)
                                  │
                                  ▼
                                 iso (installation media)
 ```
 
 Each image repo pulls `ghcr.io/projectbluefin/common:latest` as a base layer.
-testsuite gates `:latest` promotion in all three image repos.
+testsuite gates `:testing` promotion nightly and `:latest`/`:stable` promotion weekly.
 
 ---## Data donation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@ Non-compliance = automatic rejection.
 
 **Human maintainability:** Every agent action must be replicable by a human via the Justfile. No AI-optimized black boxes. Do not rename existing recipes without explicit human approval.
 
+**Skill contribution:** If you discover a pattern, fix a recurring mistake, or learn something that would help future agents, you **must** update the relevant skill file in `docs/skills/` in the same PR as your change. If no relevant skill file exists, create one and add it to the routing table in `docs/skills/README.md`. Skills are living documents — every agent improves them.
+
 ## PR Comment Policy
 
 **One comment per PR event, max.** Combine all findings into a single comment. Never post a follow-up comment for a new observation — edit the existing one instead.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,7 +43,7 @@ Verify the image signature:
 cosign verify \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp '^https://github.com/projectbluefin/dakota/.github/workflows/publish.yml@refs/heads/main$' \
-  ghcr.io/projectbluefin/dakota:latest
+  ghcr.io/projectbluefin/dakota:stable
 ```
 
 Verify the SLSA provenance:
@@ -52,5 +52,5 @@ cosign verify-attestation \
   --type https://slsa.dev/provenance/v1 \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   --certificate-identity-regexp '^https://github.com/projectbluefin/dakota/.github/workflows/publish.yml@refs/heads/main$' \
-  ghcr.io/projectbluefin/dakota:latest
+  ghcr.io/projectbluefin/dakota:stable
 ```

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -6,6 +6,7 @@ Agent entry point. Load only the skill for your current task — do not load eve
 
 | I need to... | Load |
 |---|---|
+| Review a pull request | `docs/workflow.md` + `docs/pr-checklist.md` |
 | Add a package to Bluefin | `docs/skills/add-package.md` |
 | Remove a package | `docs/skills/remove-package.md` |
 | Update a package version | `docs/skills/update-refs.md` |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -22,9 +22,24 @@ setup → publish (matrix) → e2e-gate → promote
 | `setup` | Resolves SHA and trigger event |
 | `publish` | Exports from CAS, pushes `:$sha`, signs, SBOM, attests |
 | `e2e-gate` | Smoke-tests `ghcr.io/projectbluefin/dakota:$sha` — schedule/dispatch only |
-| `promote` | Re-tags `:$sha` → `:latest` after e2e passes — schedule/dispatch only |
+| `promote` | Re-tags `:$sha` → `:testing` after e2e passes — schedule/dispatch only |
 
-`:latest` is never published without a passing e2e smoke test.
+`:testing` is never published without a passing e2e smoke test.
+
+## Weekly promotion (weekly-testing-promotion.yml)
+
+Runs Tuesday 06:00 UTC. Promotes `:testing` → `:latest` + `:stable` via digest-pinned re-tagging.
+
+```
+resolve → check-diff → promote → update-branches
+```
+
+| Job | What |
+|---|---|
+| `resolve` | Pins `:testing` digest, verifies default + NVIDIA share same source SHA |
+| `check-diff` | Skips if `:testing` == `:latest` (nothing new to promote) |
+| `promote` | Re-tags both variants as `:latest` + `:stable` |
+| `update-branches` | Fast-forwards `latest` and `stable` branches to promoted SHA |
 
 ## Schedule
 
@@ -36,7 +51,12 @@ setup → publish (matrix) → e2e-gate → promote
 
 ## Published images
 
-`ghcr.io/projectbluefin/dakota:latest` and `ghcr.io/projectbluefin/dakota:<sha>`
+`ghcr.io/projectbluefin/dakota:{testing,latest,stable}` and `ghcr.io/projectbluefin/dakota:<sha>`
+
+Streams:
+- `:testing` — nightly build, promoted after e2e passes
+- `:latest` — weekly promotion from testing (Tuesday 06:00 UTC)
+- `:stable` — weekly promotion from testing (same cadence as latest)
 
 Build triggers: `merge_group`, `schedule`, `workflow_dispatch` — **not** `pull_request`.
 

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -33,8 +33,19 @@ every future agent and contributor — not just you, and not just on one machine
 | Project overview and what Bluefin is | [`overview.md`](overview.md) |
 | ujust recipes in `files/just-overrides/` | [`.github/skills/ujust-recipes.md`](../../.github/skills/ujust-recipes.md) |
 | Installer (bootc-installer) | [`installer.md`](installer.md) |
+| PR review workflow | [`pr-review.md`](pr-review.md) |
 
-## How to add a lesson
+## Mandatory skill contribution
+
+**All agents must improve skills.** If you discover a new pattern, fix a recurring
+mistake, or learn something that would help future contributors, update the
+relevant skill file in this directory — in the same PR as your change.
+
+- If no relevant skill file exists, create one and add it to the routing table above.
+- If your lesson applies to an existing skill, add it under `## Lessons Learned`.
+- Skills are living documents. Every agent and human contributor improves them.
+
+### How to add a lesson
 
 1. Open the relevant skill file (or create a new one)
 2. Add a section under `## Lessons Learned`: `### <pattern name> (YYYY-MM-DD)`

--- a/docs/skills/ci.md
+++ b/docs/skills/ci.md
@@ -18,7 +18,7 @@ Load when debugging CI failures, understanding the build pipeline, or working wi
 | Build timeout | 330 min (job: 360 min) |
 | Remote cache server | `cache.projectbluefin.io:11002` |
 | Cache auth | mTLS — `CASD_CLIENT_CERT` (repo variable) + `CASD_CLIENT_KEY` (secret) |
-| Published image | `ghcr.io/projectbluefin/dakota:latest` and `:$SHA` |
+| Published image | `ghcr.io/projectbluefin/dakota:{testing,latest,stable}` and `:$SHA` |
 | Build logs artifact | `buildstream-logs-x86_64-<variant>` (7-day retention) |
 | Trigger (validate) | `pull_request` — `bst show --deps all`, no CAS |
 | Trigger (build) | `merge_group`, `schedule` (13:00 UTC), `workflow_dispatch` |
@@ -29,7 +29,8 @@ Load when debugging CI failures, understanding the build pipeline, or working wi
 | File | Role |
 |---|---|
 | `.github/workflows/build.yml` | BST build + push artifacts to remote CAS. Fires on merge_group/schedule/dispatch. Does NOT push to GHCR directly. |
-| `.github/workflows/publish.yml` | 4-stage pipeline: setup → publish → e2e-gate → promote. Pulls artifact from CAS, exports OCI, pushes `:$sha`, signs, attests, smoke-tests, then promotes to `:latest`. |
+| `.github/workflows/publish.yml` | 4-stage pipeline: setup → publish → e2e-gate → promote. Pulls artifact from CAS, exports OCI, pushes `:$sha`, signs, attests, smoke-tests, then promotes to `:testing`. |
+| `.github/workflows/weekly-testing-promotion.yml` | Weekly promotion (Tue 06:00 UTC): verifies `:testing` digests, re-tags as `:latest` + `:stable`, fast-forwards branches. |
 | `.github/workflows/e2e.yml` | Smoke test via projectbluefin/testsuite. Fires on PR when image-affecting paths change. |
 
 ## Trigger Behavior

--- a/docs/skills/installer.md
+++ b/docs/skills/installer.md
@@ -98,3 +98,24 @@ git merge upstream/main  # or cherry-pick relevant commits
 
 > Add entries here when you discover a new pattern or fix a recurring mistake.
 > Format: `### <pattern name> (YYYY-MM-DD)`
+
+### Installer flatpak leaks to installed system (2026-06-01)
+
+The ISO's `install-flatpaks.sh` installs the bootc-installer as a system Flatpak into `/var/lib/flatpak/`. When fisherman runs `bootc install`, it copies all system flatpaks to the target — including the installer itself. The installed system then shows the installer as an available app.
+
+**Fix:** `bluefin-remove-installer.service` (a firstboot oneshot in `files/firstboot/`) removes `org.bootcinstaller.Installer` and `.Devel` if present, then prunes unused runtimes. Gated by a stamp file at `/var/lib/ublue-os/.installer-removed`.
+
+**Root cause is in `dakota-iso`** (`install-flatpaks.sh`), but the defensive fix lives in dakota because the installed image should never ship the installer regardless of how it got there.
+
+## Dakota vs Dakota-ISO boundary
+
+The installer is NOT built from source in this repo. The boundary:
+
+| What | Where |
+|------|-------|
+| OCI image (deployed to disk) | `projectbluefin/dakota` — this repo |
+| Live ISO, installer Flatpak, squashfs | `projectbluefin/dakota-iso` |
+| Installer source (GTK4 app) | `projectbluefin/bootc-installer` |
+| Installer backend (Go) | `tuna-os/fisherman` (submodule in bootc-installer) |
+
+If a bug involves the installer UI, recipe, or ISO boot — it's a `dakota-iso` or `bootc-installer` issue. If it involves what's on the installed system after installation — it's a `dakota` issue (fix in elements or firstboot services).

--- a/docs/skills/overview.md
+++ b/docs/skills/overview.md
@@ -24,7 +24,8 @@ Load when you need context on what dakota is, how it differs from production Blu
 - The validation gate is: `bootc upgrade` on test hardware succeeds + reboot + GDM active.
 - CI green is not sufficient. Hardware confirmation is.
 
-**Production image = `ghcr.io/projectbluefin/dakota:latest`.**
+**Production image = `ghcr.io/projectbluefin/dakota:stable`.**
+- Streams: `:testing` (nightly, e2e-gated), `:latest` + `:stable` (weekly promotion)
 - When someone says "is X in the image", check the GHCR image via `skopeo inspect` or `podman run --rm` — not a local machine unless explicitly asked.
 
 **Verify hypothesis before stating root cause.**
@@ -38,7 +39,7 @@ freedesktop-sdk provides glibc/systemd/kernel, gnome-build-meta provides GNOME S
 
 **Key positioning:** Dakota is a **curated subset** of production Bluefin, not a 1:1 clone. It intentionally includes things production Bluefin doesn't have (sudo-rs, uutils-coreutils, GNOME nightly) and intentionally omits things that don't make sense for a from-source build (Nvidia drivers, ZFS, enterprise AD/Kerberos).
 
-Published image: `ghcr.io/projectbluefin/dakota:latest`
+Published image: `ghcr.io/projectbluefin/dakota:{testing,latest,stable}`
 
 ## Architecture Comparison
 

--- a/docs/skills/pr-review.md
+++ b/docs/skills/pr-review.md
@@ -1,0 +1,51 @@
+# PR Review
+
+Consolidated review workflow for dakota pull requests.
+
+## Before you review
+
+1. Read [`docs/workflow.md`](../workflow.md) — issue lifecycle, labels, branch flow
+2. Read [`docs/pr-checklist.md`](../pr-checklist.md) — per-category checklist
+
+## Review priorities (in order)
+
+1. **Branch hygiene** — PR must branch from `upstream/main`, not a fork's local `main`. Verify with `git diff upstream/main...HEAD --stat` — it should be minimal and contain only the PR's changes.
+2. **Checklist compliance** — verify the relevant items from `pr-checklist.md` for the type of change (junction bump, patch, OCI, element, etc.).
+3. **CI gate status** — `validate` and `e2e` are required status checks. If CI hasn't run, note it. If `e2e` was skipped (non-image paths), that counts as passing.
+4. **Scope discipline** — one logical change per PR. Junction bumps must not include patch modifications in the same commit.
+5. **Correctness** — element syntax, layer kind (`compose` not `stack`), cargo sources generated not hand-written, systemd units enabled via BST install commands.
+
+## Common rejection reasons
+
+| Signal | What's wrong |
+|--------|--------------|
+| Hundreds of files in diff | Branched from fork `main` instead of `upstream/main` |
+| `kind: stack` in a layer element | Should be `kind: compose` — stack produces zero filesystem output |
+| Hand-written crate entries | Must use `generate_cargo_sources.py` |
+| Missing `Closes #NNN` | PR isn't linked to an issue |
+| `patches/` change in a junction bump commit | Must be separate commits or separate PRs |
+| No `just lint` / `just boot-test` evidence | Verification gate not met |
+
+## How to give feedback
+
+- **Guide, don't just reject.** Point contributors toward the correct pattern in `docs/workflow.md` or `docs/pr-checklist.md`.
+- **One comment per review event.** Combine all findings into a single review comment. Never post follow-ups for new observations — edit the existing comment.
+- **Do not duplicate GitHub UI.** Don't restate approval counts, merge queue status, or CI summaries that GitHub already shows.
+- **Minimal test reports.** What ran, pass/fail, blockers. No diff summaries.
+
+## Ghost detection
+
+Agent-assisted PRs are identified by the checked template checkbox:
+`[x] I am using an agent and I take responsibility for this PR`
+
+Hold these to the same standard as human PRs. The operator is accountable.
+
+## Mergeraptor pre-approval
+
+Junction-only bumps from `mergeraptor[bot]` are pre-approved once `validate` and `e2e` pass (or e2e is skipped for non-image paths). No human review required for those.
+
+## Lessons Learned
+
+Add new lessons below as: `### <pattern name> (YYYY-MM-DD)`
+
+---

--- a/docs/skills/quickstart.md
+++ b/docs/skills/quickstart.md
@@ -39,6 +39,34 @@ Zero-context entry point for routine dakota maintenance — add package, remove 
 | `auto-merge` | App packages, shell extensions — low-risk, squash-merged automatically |
 | `manual-merge` | Junctions, Rust elements — requires human review |
 
+## Fix an Issue — End-to-End
+
+```bash
+# 1. Claim the issue
+gh issue comment 635 --repo projectbluefin/dakota --body "/claim"
+
+# 2. Branch from upstream/main
+git checkout upstream/main -b fix/short-description
+
+# 3. Make changes, validate
+just validate && just lint
+
+# 4. Commit with correct trailer
+git commit -m "fix(bluefin): short description
+
+Closes #635
+
+Assisted-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+
+# 5. Push to upstream (never castrojo fork)
+git push upstream fix/short-description
+
+# 6. Open PR with checklist checkbox checked
+gh pr create --repo projectbluefin/dakota ...
+```
+
+If the issue is still `needs-triage` (not yet `status/approved`), ask the user before claiming — agents don't self-approve issues.
+
 ## Commit Conventions
 
 ```text
@@ -47,6 +75,8 @@ chore(deps): update <name>
 fix(bluefin): <description>
 chore: remove <name>
 ```
+
+**Trailer:** Always `Assisted-by:` or `Signed-off-by:` — never `Co-authored-by:`. This is a hard rule from `docs/pr-checklist.md`.
 
 ## Key Paths
 

--- a/elements/bluefin/firstboot-date.bst
+++ b/elements/bluefin/firstboot-date.bst
@@ -18,7 +18,9 @@ public:
 config:
   install-commands:
   - install -Dm644 ublue-firstboot-date.service "%{install-root}/usr/lib/systemd/system/ublue-firstboot-date.service"
+  - install -Dm644 bluefin-remove-installer.service "%{install-root}/usr/lib/systemd/system/bluefin-remove-installer.service"
   - install -Dm644 fastfetch.jsonc "%{install-root}/usr/share/ublue-os/fastfetch.jsonc"
   - mkdir -p "%{install-root}/usr/lib/systemd/system/multi-user.target.wants/"
   - ln -sf ../ublue-firstboot-date.service "%{install-root}/usr/lib/systemd/system/multi-user.target.wants/ublue-firstboot-date.service"
+  - ln -sf ../bluefin-remove-installer.service "%{install-root}/usr/lib/systemd/system/multi-user.target.wants/bluefin-remove-installer.service"
   - "%{install-extra}"

--- a/files/firstboot/bluefin-remove-installer.service
+++ b/files/firstboot/bluefin-remove-installer.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Remove bootc installer if present on installed system
+ConditionPathExists=!/var/lib/ublue-os/.installer-removed
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c '\
+  removed=0; \
+  for app in org.bootcinstaller.Installer org.bootcinstaller.Installer.Devel; do \
+    if flatpak info --system "$app" >/dev/null 2>&1; then \
+      flatpak uninstall --system --noninteractive "$app" && removed=1; \
+    fi; \
+  done; \
+  flatpak uninstall --system --noninteractive --unused 2>/dev/null || true; \
+  mkdir -p /var/lib/ublue-os && touch /var/lib/ublue-os/.installer-removed'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
Adds `environment: production` to the `promote` job in weekly promotion workflow, enforcing required approval gates before testing→stable promotion.

## Details
- Environment configured with required reviewers at GitHub UI level
- Gate applies to both default and NVIDIA variants in matrix builds
- Resolves projectbluefin/actions#17 (Track C-1)

## Test Plan
- Verify that manual promotion workflow runs require approval from required reviewers
- Confirm that testing→latest/stable promotion is blocked until approved